### PR TITLE
Add ACL property

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ custom:
       localDir: dist/assets # required
     - bucketName: my-other-site
       localDir: path/to/other-site
+      acl: public-read # optional
 
 resources:
   Resources:

--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ class ServerlessS3Sync {
       if (!s.hasOwnProperty('bucketPrefix')) {
         bucketPrefix = s.bucketPrefix;
       }
+      let acl = 'private';
+      if (s.hasOwnProperty('acl')) {
+        acl = s.acl;
+      }
       if (!s.bucketName || !s.localDir) {
         throw 'Invalid custom.s3Sync';
       }
@@ -63,7 +67,8 @@ class ServerlessS3Sync {
           followSymlinks: false,
           s3Params: {
             Bucket: s.bucketName,
-            Prefix: bucketPrefix
+            Prefix: bucketPrefix,
+            ACL: acl
           }
         };
         const uploader = this.client().uploadDir(params);


### PR DESCRIPTION
Added ACL property so you can define what the acl for the uploaded files will be.

As the used S3 library only syncs new files, this will only work when uploading or syncing new files. Existing files will keep their current ACL.