### PR TITLE
fix logic for bucketPrefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class ServerlessS3Sync {
     const servicePath = this.servicePath;
     const promises = this.s3Sync.map((s) => {
       let bucketPrefix = '';
-      if (!s.hasOwnProperty('bucketPrefix')) {
+      if (s.hasOwnProperty('bucketPrefix')) {
         bucketPrefix = s.bucketPrefix;
       }
       let acl = 'private';


### PR DESCRIPTION
Currently the logic says that bucketPrefix should be set if bucketPrefix does not exist, I removed the !, correcting the logic.