### PR TITLE
Add support for defaultContentType property

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ custom:
       localDir: path/to/other-site
       acl: public-read # optional
       followSymlinks: true # optional
+      defaultContentType: text/html # optional
       params: # optional
         - index.html:
             CacheControl: 'no-cache'

--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ class ServerlessS3Sync {
       if (s.hasOwnProperty('followSymlinks')) {
         followSymlinks = s.followSymlinks;
       }
+      let defaultContentType = undefined
+      if (s.hasOwnProperty('defaultContentType')) {
+        defaultContentType = s.defaultContentType;
+      }
       if (!s.bucketName || !s.localDir) {
         throw 'Invalid custom.s3Sync';
       }
@@ -92,6 +96,9 @@ class ServerlessS3Sync {
             ACL: acl
           }
         };
+        if (typeof(defaultContentType) != 'undefined') {
+          Object.assign(params, {defaultContentType: defaultContentType})
+        }
         const uploader = this.client().uploadDir(params);
         uploader.on('error', (err) => {
           throw err;


### PR DESCRIPTION
I needed to have some HTML files on S3 without extension. But files without extension get uploaded as `application/octet-stream`, which triggers a download instead of displaying the files in the browser.

This PR adds support for the `defaultContentType` property. When defined, files without extension or with unrecognized extensions will be uploaded using the given content type.