### PR TITLE
Fix passing s3Client to `monolambda/s3`

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,12 +33,12 @@ class ServerlessS3Sync {
   client() {
     const provider = this.serverless.getProvider('aws');
     const awsCredentials = provider.getCredentials();
-    const awsS3Client = new provider.sdk.S3({
+    const s3Client = new provider.sdk.S3({
       region: awsCredentials.region,
       credentials: awsCredentials.credentials,
     });
 
-    return s3.createClient(awsS3Client);
+    return s3.createClient({ s3Client });
   }
 
   sync() {


### PR DESCRIPTION
monolambda/s3 client accepts an options argument, which is an object and not an instance of s3 client. I found this issue when I was trying to use the plugin for syncing with another profile (non default). Because s3Client was not passed correctly it defaulted to the `AWS.S3` with default profile, which resulted in AccessDenied error.