### PR TITLE
Resolve localDir paths so that minimatch can match on resources in pa…

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const BbPromise = require('bluebird');
 const s3 = require('@monolambda/s3');
 const chalk = require('chalk');
 const minimatch = require('minimatch');
+const path = require('path');
 
 const messagePrefix = 'S3 Sync: ';
 
@@ -87,7 +88,7 @@ class ServerlessS3Sync {
             if(Array.isArray(s.params)) {
               s.params.forEach((param) => {
                 const glob = Object.keys(param)[0];
-                if(minimatch(localFile, `${localDir}/${glob}`)) {
+                if(minimatch(localFile, `${path.resolve(localDir)}/${glob}`)) {
                   Object.assign(s3Params, param[glob] || {});
                 }
               });


### PR DESCRIPTION
If the `localDir` lives above the current working directory, minimatch is unable to find a match, causing params to not be applied.

```
  s3Sync:
    - bucketName: ${self:custom.myS3Bucket}
      localDir: ../../pathTo/myDistFolder
      params:
        - index.html:
            CacheControl: 'no-cache'
        - "*.js":
            CacheControl: 'public, max-age=31536000'
```

This resolves the `localDir` path prior to attempting to check for a match