### PR TITLE
Fixes k1LoW/serverless-s3-sync#31 by ignoring the first key (glob).

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ class ServerlessS3Sync {
               s.params.forEach((param) => {
                 const glob = Object.keys(param)[0];
                 if(minimatch(localFile, `${path.resolve(localDir)}/${glob}`)) {
-                  Object.assign(s3Params, param[glob] || {});
+                  Object.assign(s3Params, this.extractMetaParams(param) || {});
                 }
               });
             }
@@ -177,6 +177,15 @@ class ServerlessS3Sync {
         cli.consoleLog('');
         cli.consoleLog(`${messagePrefix}${chalk.yellow('Removed.')}`);
       });
+  }
+
+  extractMetaParams(config) {
+    const validParams = {};
+    const keys = Object.keys(config);
+    for (let i = 1; i < keys.length; i++) {
+      validParams[keys[i]] = config[keys[i]];
+    }
+    return validParams;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-sync",
-  "version": "1.8.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-sync",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hey all,

This fixes the issue with CacheControl values not making it into s3 metadata.