### PR TITLE
Adds support for fetching the bucket name from the stack output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ custom:
             CacheControl: 'no-cache'
         - "*.js":
             CacheControl: 'public, max-age=31536000'
+    - bucketNameKey: AnotherBucketNameOutputKey
+      localDir: path/to/another
 
 resources:
   Resources:
@@ -55,6 +57,11 @@ resources:
         WebsiteConfiguration:
           IndexDocument: index.html
           ErrorDocument: error.html
+    AnotherBucket:
+      Type: AWS::S3::Bucket
+  Outputs:
+    AnotherBucketNameOutputKey:
+      Value: !Ref AnotherBucket
 ```
 
 ## Usage

--- a/resolveStackOutput.js
+++ b/resolveStackOutput.js
@@ -1,0 +1,24 @@
+function resolveStackOutput(plugin, outputKey) {
+  const provider = plugin.serverless.getProvider('aws');
+  const awsCredentials = provider.getCredentials();
+  const cfn = new provider.sdk.CloudFormation({
+    region: awsCredentials.region,
+    credentials: awsCredentials.credentials
+  });
+  const stackName = provider.naming.getStackName();
+
+  return cfn
+    .describeStacks({ StackName: stackName })
+    .promise()
+    .then(data => {
+      const output = data.Stacks[0].Outputs.find(
+        e => e.OutputKey === outputKey
+      );
+      if (!output) {
+        throw `Failed to resolve stack Output '${outputKey}' in stack '${stackName}'`;
+      }
+      return output.OutputValue;
+    });
+}
+
+module.exports = resolveStackOutput;


### PR DESCRIPTION
This PR allows the name of a bucket to optionally be fetched from the stack output. This is helpful when the name of the bucket is not known before the stack is created. In such cases the user can now write the name of the bucket as an Output value and provide the Output key as a `bucketNameKey` property.

This fixes issue #6.

The implementation is inspired from the [serverless-cloudfront-invalidate](https://github.com/aghadiry/serverless-cloudfront-invalidate) plugin which does something very similar.

NOTE: Most of these changes are whitespace/indentation so in the diff view you might choose Diff Settings -> Hide whitespace changes.