### PR TITLE
Solution for #35 - update Cache-Control headers even if files don't change

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,6 +220,7 @@ class ServerlessS3Sync {
             Key: file.name.replace(localDir, ''),
             Bucket: s.bucketName,
             Metadata: file.params,
+            ACL: acl,
             MetadataDirective: 'REPLACE'
           };
           const uploader = this.client().copyObject(params);

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const s3 = require('@auth0/s3');
 const chalk = require('chalk');
 const minimatch = require('minimatch');
 const path = require('path');
-
+const fs = require('fs');
 const messagePrefix = 'S3 Sync: ';
 
 class ServerlessS3Sync {
@@ -18,7 +18,8 @@ class ServerlessS3Sync {
       s3sync: {
         usage: 'Sync directories and S3 prefixes',
         lifecycleEvents: [
-          'sync'
+          'sync',
+          'metadata'
         ]
       }
     };
@@ -26,7 +27,8 @@ class ServerlessS3Sync {
     this.hooks = {
       'after:deploy:deploy': () => options.nos3sync?undefined:BbPromise.bind(this).then(this.sync),
       'before:remove:remove': () => BbPromise.bind(this).then(this.clear),
-      's3sync:sync': () => BbPromise.bind(this).then(this.sync)
+      's3sync:sync': () => BbPromise.bind(this).then(this.sync),
+      's3sync:metadata': () => BbPromise.bind(this).then(this.syncMetadata)
     };
   }
 
@@ -177,6 +179,78 @@ class ServerlessS3Sync {
         cli.consoleLog('');
         cli.consoleLog(`${messagePrefix}${chalk.yellow('Removed.')}`);
       });
+  }
+
+  syncMetadata() {
+    const s3Sync = this.serverless.service.custom.s3Sync;
+    const cli = this.serverless.cli;
+    if (!Array.isArray(s3Sync)) {
+      cli.consoleLog(`${messagePrefix}${chalk.red('No configuration found')}`)
+      return Promise.resolve();
+    }
+    cli.consoleLog(`${messagePrefix}${chalk.yellow('Syncing metadata...')}`);
+    const servicePath = this.servicePath;
+    const promises = s3Sync.map( async (s) => {
+      let bucketPrefix = '';
+      if (s.hasOwnProperty('bucketPrefix')) {
+        bucketPrefix = s.bucketPrefix;
+      }
+      let acl = 'private';
+      if (s.hasOwnProperty('acl')) {
+        acl = s.acl;
+      }
+      if (!s.bucketName || !s.localDir) {
+        throw 'Invalid custom.s3Sync';
+      }
+      const localDir = [servicePath, s.localDir].join('/');
+      let filesToSync = [];
+      if(Array.isArray(s.params)) {
+        s.params.forEach((param) => {
+          const glob = Object.keys(param)[0];
+          let files = this.getLocalFiles(localDir, []);
+          minimatch.match(files, `${path.resolve(localDir)}/${glob}`, {matchBase: true}).forEach((match) => {
+            filesToSync.push({name: match, params: this.extractMetaParams(param)});
+          });
+        });
+      }
+      return filesToSync.forEach((file) => {
+        return new Promise((resolve) => {
+          let params = {
+            CopySource: file.name.replace(localDir, `${s.bucketName}${bucketPrefix == '' ? '' : bucketPrefix}/`),
+            Key: file.name.replace(localDir, ''),
+            Bucket: s.bucketName,
+            Metadata: file.params,
+            MetadataDirective: 'REPLACE'
+          };
+          const uploader = this.client().copyObject(params);
+          uploader.on('error', (err) => {
+            throw err;
+          });
+          uploader.on('end', () => {
+            resolve('done');
+          });
+        });
+      });
+    });
+    cli.consoleLog(`${JSON.stringify(promises)}`);
+    return Promise.all((promises))
+      .then(() => {
+        cli.printDot();
+        cli.consoleLog('');
+        cli.consoleLog(`${messagePrefix}${chalk.yellow('Synced metadata.')}`);
+      });
+  }
+  
+  getLocalFiles(dir, files) {
+    fs.readdirSync(dir).forEach(file => {
+      let fullPath = path.join(dir, file);
+      if (fs.lstatSync(fullPath).isDirectory()) {
+        this.getLocalFiles(fullPath, files);
+      } else {
+        files.push(fullPath);
+      }  
+    });
+    return files;
   }
 
   extractMetaParams(config) {


### PR DESCRIPTION
This PR should resolve #35 
this process will ensure metadata is up to date with every s3sync call.

after the s3sync:sync process the `s3sync:metadata` process follows.

this will take a look at the *custom.s3Sync[n].params* values, and match the globs based on the configuration of the *custom.s3Sync[n]* parameters.  Once it knows all of the files that have metadata altered by this file, it will perform a s3api call on **copy-object**, which is nicely wrapped in the **@oauth0/s3** lib. 

There shouldn't exactly be any issues with using **copy-object**, one thing to note is that the **copy-object** api call will explicitly alter the readability of the file.  For example, if you call the s3api **copy-object** on a *public-read* acl s3 file, and you don't explicitly give it an acl, it will make it *private* by default.  This shouldn't be a problem considering if you are wanting your files to have an alternate acl then you set this in *custom.s3Sync[n].acl* and the `s3sync:metadata` will always take this into account.

Please let me know if there are any alterations you need to get this merged, it is a blocker for us and we'd love to not have to point our *package.json* at some other source.

あけおめ
ありがとうございます
