### PR TITLE
intended the syncMetadata to run with every deploy as well as s3sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ class ServerlessS3Sync {
     };
 
     this.hooks = {
-      'after:deploy:deploy': () => options.nos3sync?undefined:BbPromise.bind(this).then(this.sync),
+      'after:deploy:deploy': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata),
       'before:remove:remove': () => BbPromise.bind(this).then(this.clear),
       's3sync:sync': () => BbPromise.bind(this).then(this.sync),
       's3sync:metadata': () => BbPromise.bind(this).then(this.syncMetadata)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-sync",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This was missed and intended to be part of the original release.

If we want to run `sls s3Sync` then we expect it to sync the metadata even if the files have not changed (md5 is the same).
This behavior should also happen with `sls deploy`, as in some cases there are developers who make content changes that are specific to the file metadata, and not to the file itself.  We want to ensure that when committed to a repository, and CI/CD is ran (using `sls deploy`) then it should ensure the state of the metadata matches the intended state of the deployment.

Thanks