### PR TITLE
support bucketNameKey in syncMetadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ class ServerlessS3Sync {
       if (s.hasOwnProperty('acl')) {
         acl = s.acl;
       }
-      if (!s.bucketName || !s.localDir) {
+      if ((!s.bucketName && !s.bucketNameKey) || !s.localDir) {
         throw 'Invalid custom.s3Sync';
       }
       const localDir = path.join(servicePath, s.localDir);


### PR DESCRIPTION
I get an error when deploying with the new bucketNameKey feature.  this fixes it.