### PR TITLE
Detect slashes on bucketPrefix and fix as required

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,8 +200,8 @@ class ServerlessS3Sync {
     const servicePath = this.servicePath;
     const promises = s3Sync.map( async (s) => {
       let bucketPrefix = '';
-      if (s.hasOwnProperty('bucketPrefix')) {
-        bucketPrefix = s.bucketPrefix;
+      if (s.hasOwnProperty('bucketPrefix') && s.bucketPrefix.length > 0) {
+        bucketPrefix = s.bucketPrefix.replace(/\/?$/, '').replace(/^\/?/, '/')
       }
       let acl = 'private';
       if (s.hasOwnProperty('acl')) {


### PR DESCRIPTION
This PR will ensure that the `bucketPrefix` (if defined and not empty) is prefixed by a slash and does not contain a trailing slash.