### PR TITLE
Support credentials from Serverless Framework Enterprise

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,6 @@ class ServerlessS3Sync {
 		region = provider.getCredentials().region
 		awsCredentials = provider.getCredentials().credentials
 	}
-	console.log(awsCredentials)
     const s3Client = new provider.sdk.S3({
       region: region,
       credentials: awsCredentials

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ class ServerlessS3Sync {
   client() {
     const provider = this.serverless.getProvider('aws');
 	let awsCredentials, region;
-	if (provider.cachedCredentials) {
+	if (provider.cachedCredentials && typeof(provider.cachedCredentials.accessKeyId) != 'undefined'
+		&& typeof(provider.cachedCredentials.secretAccessKey) != 'undefined'
+		&& typeof(provider.cachedCredentials.sessionToken) != 'undefined') {
 		region = provider.cachedCredentials.region
 		awsCredentials = {
 			accessKeyId: provider.cachedCredentials.accessKeyId,

--- a/index.js
+++ b/index.js
@@ -38,12 +38,23 @@ class ServerlessS3Sync {
 
   client() {
     const provider = this.serverless.getProvider('aws');
-    const awsCredentials = provider.getCredentials();
+	let awsCredentials, region;
+	if (provider.cachedCredentials) {
+		region = provider.cachedCredentials.region
+		awsCredentials = {
+			accessKeyId: provider.cachedCredentials.accessKeyId,
+			secretAccessKey: provider.cachedCredentials.secretAccessKey,
+			sessionToken: provider.cachedCredentials.sessionToken,
+		}
+	} else {
+		region = provider.getCredentials().region
+		awsCredentials = provider.getCredentials().credentials
+	}
+	console.log(awsCredentials)
     const s3Client = new provider.sdk.S3({
-      region: awsCredentials.region,
-      credentials: awsCredentials.credentials,
+      region: region,
+      credentials: awsCredentials
     });
-
     return s3.createClient({ s3Client });
   }
 


### PR DESCRIPTION
Right now, The Serverless Framework Enterprise has released as additional features of the framework.
https://dashboard.serverless.com/

Using the following functionality, you don't need to directly add AWS Credentials to CI/CD env since it allows you to deploy from the AWS account of the enterprise using the trusted relationship of AWS IAM between each AWS accounts.
https://serverless.com/framework/docs/dashboard/access-roles/

To support for that, this plugin needs to use `provider.cachedCredentials` which the credentials from the enterprise is in.

You will be able to use the credentials from the enterprise if `provider.cachedCredentials` is not null. if not, using the current credentials system if merging this PR.

仕事で使うのでよろしくおねがいします！
