### PR TITLE
Add a `preCommand` option for running scripts before sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const resolveStackOutput = require('./resolveStackOutput')
 const messagePrefix = 'S3 Sync: ';
 const mime = require('mime');
+const child_process = require('child_process');
 
 const toS3Path = (osPath) => osPath.replace(new RegExp(`\\${path.sep}`, 'g'), '/');
 
@@ -113,6 +114,10 @@ class ServerlessS3Sync {
       if (s.hasOwnProperty('deleteRemoved')) {
           deleteRemoved = s.deleteRemoved;
       }
+      let preCommand = undefined
+      if (s.hasOwnProperty('preCommand')) {
+          preCommand = s.preCommand;
+      }
 
       return this.getBucketName(s)
         .then(bucketName => {
@@ -123,6 +128,11 @@ class ServerlessS3Sync {
           }
           return new Promise((resolve) => {
             const localDir = [servicePath, s.localDir].join('/');
+
+            if (typeof(preCommand) != 'undefined') {
+              cli.consoleLog(`${messagePrefix}${chalk.yellow('Running pre-command...')}`);
+              child_process.execSync(preCommand, { stdio: 'inherit' });
+            }
 
             const params = {
               maxAsyncS3: 5,


### PR DESCRIPTION
# Background
I'm attempting to have a single source project containing both React app and serverless spec, and have `sls deploy`:

1. Deploy backend resources to AWS
2. Use [`@lucas-carneiro/serverless-stack-output`](https://github.com/lucas-carneiro/serverless-stack-output) to update React app with details from CloudFormation
3. Run `npm build`
4. Use `serverless-s3-sync` to copy the React `build/` directory up to S3.

After getting the output of the CloudFormation stacks written, I need to do something to update the React runtime. I've tried to use [`serverless-plugin-scripts`](https://github.com/mvila/serverless-plugin-scripts), but unfortunately I don't think the dynamic hooking and ordering can be made to work. It'd also be nice to avoid an extra dependency.

# Purpose
This PR adds a `preCommand` option to `s3Sync`, allowing a command to be run before the folder is uploaded to S3:

```yaml
custom:
  siteBucket: example-${self:provider.stage}
  s3Sync:
    - bucketName: ${self:custom.siteBucket}
      localDir: build/
      preCommand: npm run build
```