### PR TITLE
Skip get/putBucketTagging requests when bucketTags option is not configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,14 +334,17 @@ class ServerlessS3Sync {
         throw 'Invalid custom.s3Sync';
       }
 
-      // convert the tag key/value pairs into a TagSet structure for the putBucketTagging command
-      let tagsToUpdate = [];
-      if (s.bucketTags) {
-        tagsToUpdate = Object.keys(s.bucketTags).map(tagKey => ({
-          Key: tagKey,
-          Value: s.bucketTags[tagKey]
-        }));
+      if (!s.bucketTags) {
+        // bucket tags not configured for this bucket, skip it
+        // so we don't require additional s3:getBucketTagging permissions
+        return null;
       }
+
+      // convert the tag key/value pairs into a TagSet structure for the putBucketTagging command
+      const tagsToUpdate = Object.keys(s.bucketTags).map(tagKey => ({
+        Key: tagKey,
+        Value: s.bucketTags[tagKey]
+      }));
 
       return this.getBucketName(s)
         .then(bucketName => {


### PR DESCRIPTION
Solves a bug that I introduced in previous pull request #61: when `bucketTags` setting is not specified, the plugin would still issue get/putBucketTagging requests to S3. These requests are unnecessary. 

Furthermore (as it was my case), they were introducing a breaking change due to the fact that a deployment that worked before may fail to deploy if it does not have s3:PutBucketTagging and s3:GetBucketTagging permissions for the IAM role that executes the deployment.

Now we're skipping the bucket tag actions completely when bucketTags node is missing from the config.