### PR TITLE
Add example of how to reference bucket name from another stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ plugins:
 ```yaml
 custom:
   s3Sync:
+    # A simple configuration for copying static assets
     - bucketName: my-static-site-assets # required
       bucketPrefix: assets/ # optional
       localDir: dist/assets # required
+
+    # An example of possible configuration options
     - bucketName: my-other-site
       localDir: path/to/other-site
       acl: public-read # optional
@@ -43,8 +46,15 @@ custom:
       bucketTags: # optional, these are appended to existing S3 bucket tags (overwriting tags with the same key)
         tagKey1: tagValue1
         tagKey2: tagValue2
+
+    # This references bucket name from the output of the current stack
     - bucketNameKey: AnotherBucketNameOutputKey
       localDir: path/to/another
+
+    # ... but can also reference it from the output of another stack,
+    # see https://www.serverless.com/framework/docs/providers/aws/guide/variables#reference-cloudformation-outputs
+    - bucketName: ${cf:another-cf-stack-name.ExternalBucketOutputKey}
+      localDir: path
 
 resources:
   Resources:


### PR DESCRIPTION
Improved the docs a bit, to show how one can reference outputs from another stack.
Provides a good-enough alternative for supporting Fn::ImportValue, this way you can maybe close #19.