### PR TITLE
Fixed bug with resolving region in resolving stack output

### DIFF
--- a/resolveStackOutput.js
+++ b/resolveStackOutput.js
@@ -2,7 +2,7 @@ function resolveStackOutput(plugin, outputKey) {
   const provider = plugin.serverless.getProvider('aws');
   const awsCredentials = provider.getCredentials();
   const cfn = new provider.sdk.CloudFormation({
-    region: awsCredentials.region,
+    region: provider.getRegion(),
     credentials: awsCredentials.credentials
   });
   const stackName = provider.naming.getStackName();


### PR DESCRIPTION
I always get the error message:

```
S3 Sync: Syncing directories and S3 prefixes...

  Config Error -------------------------------------------

  ConfigError: Missing region in config
      at Request.VALIDATE_REGION (C:\snapshot\serverless\node_modules\aws-sdk\lib\event_listeners.js:92:45)
      at Request.callListeners (C:\snapshot\serverless\node_modules\aws-sdk\lib\sequential_executor.js:106:20)
      at callNextListener (C:\snapshot\serverless\node_modules\aws-sdk\lib\sequential_executor.js:96:12)
      at C:\snapshot\serverless\node_modules\aws-sdk\lib\event_listeners.js:86:9
      at finish (C:\snapshot\serverless\node_modules\aws-sdk\lib\config.js:379:7)
      at C:\snapshot\serverless\node_modules\aws-sdk\lib\config.js:397:9
      at SharedIniFileCredentials.get (C:\snapshot\serverless\node_modules\aws-sdk\lib\credentials.js:127:7)
      at getAsyncCredentials (C:\snapshot\serverless\node_modules\aws-sdk\lib\config.js:391:24)
      at Config.getCredentials (C:\snapshot\serverless\node_modules\aws-sdk\lib\config.js:411:9)
      at Request.VALIDATE_CREDENTIALS (C:\snapshot\serverless\node_modules\aws-sdk\lib\event_listeners.js:81:26)
      at Request.callListeners (C:\snapshot\serverless\node_modules\aws-sdk\lib\sequential_executor.js:102:18)
      at Request.emit (C:\snapshot\serverless\node_modules\aws-sdk\lib\sequential_executor.js:78:10)
      at Request.emit (C:\snapshot\serverless\node_modules\aws-sdk\lib\request.js:683:14)
      at Request.transition (C:\snapshot\serverless\node_modules\aws-sdk\lib\request.js:22:10)
      at AcceptorStateMachine.runTo (C:\snapshot\serverless\node_modules\aws-sdk\lib\state_machine.js:14:12)
      at Request.runTo (C:\snapshot\serverless\node_modules\aws-sdk\lib\request.js:403:15)
      at C:\snapshot\serverless\node_modules\aws-sdk\lib\request.js:792:12
      at new Promise (<anonymous>)
      at Request.promise (C:\snapshot\serverless\node_modules\aws-sdk\lib\request.js:778:12)
      at resolveStackOutput (C:\xampp\htdocs\node_modules\serverless-s3-sync\resolveStackOutput.js:13:6)
      at ServerlessS3Sync.getBucketName (C:\xampp\htdocs\node_modules\serverless-s3-sync\index.js:420:14)
      at C:\xampp\htdocs\node_modules\serverless-s3-sync\index.js:126:19
      at Array.map (<anonymous>)
      at ServerlessS3Sync.sync (C:\xampp\htdocs\node_modules\serverless-s3-sync\index.js:97:29)
      at ServerlessS3Sync.tryCatcher (C:\xampp\htdocs\node_modules\bluebird\js\release\util.js:16:23)
      at Promise._settlePromiseFromHandler (C:\xampp\htdocs\node_modules\bluebird\js\release\promise.js:547:31)
      at Promise._settlePromise (C:\xampp\htdocs\node_modules\bluebird\js\release\promise.js:604:18)
      at Promise._settlePromiseCtx (C:\xampp\htdocs\node_modules\bluebird\js\release\promise.js:641:10)
      at _drainQueueStep (C:\xampp\htdocs\node_modules\bluebird\js\release\async.js:97:12)
      at _drainQueue (C:\xampp\htdocs\node_modules\bluebird\js\release\async.js:86:9)
      at Async._drainQueues (C:\xampp\htdocs\node_modules\bluebird\js\release\async.js:102:5)
      at Immediate.Async.drainQueues (C:\xampp\htdocs\node_modules\bluebird\js\release\async.js:15:14)
      at processImmediate (internal/timers.js:439:21)
      at process.topLevelDomainCallback (domain.js:130:23)

     For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
```

And I configured the region in any place - except in the environment variables because then its working.
So I checked how other plugins solving this and ét voilá: I implemented it here 👍 

Issue solved.