### PR TITLE
Ignore error if a file/dir did not exist when syncMetadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -393,8 +393,21 @@ class ServerlessS3Sync {
   }
 
   getLocalFiles(dir, files) {
+    const cli = this.serverless.cli;
+    try {
+      fs.accessSync(dir, fs.constants.R_OK);
+    } catch (e) {
+      cli.consoleLog(`${messagePrefix}${chalk.red(`The directory ${dir} does not exist.`)}`);
+      return files;
+    }
     fs.readdirSync(dir).forEach(file => {
       let fullPath = path.join(dir, file);
+      try {
+        fs.accessSync(fullPath, fs.constants.R_OK);
+      } catch (e) {
+        cli.consoleLog(`${messagePrefix}${chalk.red(`The file ${fullPath} doesn not exist.`)}`);
+        return;
+      }
       if (fs.lstatSync(fullPath).isDirectory()) {
         this.getLocalFiles(fullPath, files);
       } else {


### PR DESCRIPTION
I faced the problem that the sync was finished but the syncMetadata won't be finished. Because syncMetadata will find all files (even though if a user specified the bucket), non-exist localDir was caused the error. So, I fixed the getLocalFiles to ignore non-exist files.