### PR TITLE
Add `OnlyForEnv` parameter directive

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,6 +287,8 @@ class ServerlessS3Sync {
               filesToSync = filesToSync.filter(e => e.name !== match);
               return;
             }
+            // to avoid Unexpected Parameter error
+            delete params['OnlyForEnv'];
             filesToSync.push({name: match, params});
           });
         });


### PR DESCRIPTION
Purpose: To upload a file only in a specific environment.

**How to use:**

in serverless.yaml:

```yml
custom:
  s3Sync:
    - bucketName: my-bucket
      localDir: files
      params:
        - "prod.json":
            OnlyForEnv: prod
        - "stg.json":
            OnlyForEnv: stg
        - "dev.json":
            OnlyForEnv: dev
```

The `prod.json` will be uploaded only in the `prod` environment, other files too.
