### PR TITLE
add serverless-offline + serverless-s3-local support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,24 @@ Run `sls deploy --nos3sync`, deploy your serverless stack without syncing local 
 ### `sls s3sync`
 
 Sync local directories and S3 prefixes.
+
+### Offline usage
+
+If also using the plugins `serverless-offline` and `serverless-s3-local`, sync can be supported during development by placing the bucket configuration(s) into the `buckets` object and specifying the alterate `endpoint` (see below).
+
+```yaml
+custom:
+  s3Sync:
+    # an alternate s3 endpoint
+    endpoint: http://localhost:4569
+    buckets:
+    # A simple configuration for copying static assets
+    - bucketName: my-static-site-assets # required
+      bucketPrefix: assets/ # optional
+      localDir: dist/assets # required
+# ...
+```
+
+run `sls offline start --profile s3local` to sync to the local s3 bucket instead of Amazon AWS S3
+
+run `sls deploy` for normal deployment

--- a/index.js
+++ b/index.js
@@ -60,6 +60,14 @@ class ServerlessS3Sync {
     };
   }
 
+  isOffline() {
+    return String(this.options.offline).toUpperCase() === 'TRUE' || process.env.IS_OFFLINE;
+  }
+
+  getEndpoint() {
+      return this.serverless.service.custom.s3Sync.hasOwnProperty('endpoint') ? this.serverless.service.custom.s3Sync.endpoint : null;
+  }
+
   client() {
     const provider = this.serverless.getProvider('aws');
 	let awsCredentials, region;
@@ -83,7 +91,7 @@ class ServerlessS3Sync {
     region: region,
     credentials: awsCredentials
   };
-  if(this.serverless.service.custom.s3Sync.hasOwnProperty('endpoint') && (String(this.options.offline).toUpperCase() === 'TRUE' || process.env.IS_OFFLINE)) {
+  if(this.getEndpoint() && this.isOffline()) {
     s3Options.endpoint = new provider.sdk.Endpoint(this.serverless.service.custom.s3Sync.endpoint);
     s3Options.s3ForcePathStyle = true;
   }
@@ -91,7 +99,7 @@ class ServerlessS3Sync {
       region: region,
       credentials: awsCredentials
     });
-    if(this.serverless.service.custom.s3Sync.hasOwnProperty('endpoint') && String(this.options.offline).toUpperCase() === 'TRUE' || process.env.IS_OFFLINE) {
+    if(this.getEndpoint() && this.isOffline()) {
       //see: https://github.com/aws/aws-sdk-js/issues/1157
       s3Client.shouldDisableBodySigning = () => true
     }


### PR DESCRIPTION
PR adds support for serverless-offline [https://www.serverless.com/plugins/serverless-offline](https://www.serverless.com/plugins/serverless-offline) with serveless-s3-local [https://www.serverless.com/plugins/serverless-s3-local](https://www.serverless.com/plugins/serverless-s3-local)

To use, move existing buckets into a `buckets` field and include an `endpoint` field in the `custom.s3Sync` section of `serverless.yaml`.

PR supports existing `serverless.yaml` configuration for backwards compatibility. 