### PR TITLE
Take --nos3sync into account during serverless remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Run `sls remove`, S3 objects in S3 prefixes are removed.
 
 Run `sls deploy --nos3sync`, deploy your serverless stack without syncing local directories and S3 prefixes.
 
+Run `sls remove --nos3sync`, remove your serverless stack without removing S3 objects from the target S3 buckets.
+
 ### `sls s3sync`
 
 Sync local directories and S3 prefixes.

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class ServerlessS3Sync {
       'after:deploy:deploy': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
       'after:offline:start:init': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
       'after:offline:start': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
-      'before:remove:remove': () => BbPromise.bind(this).then(this.clear),
+      'before:remove:remove': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.clear),
       's3sync:sync': () => BbPromise.bind(this).then(this.sync),
       's3sync:metadata': () => BbPromise.bind(this).then(this.syncMetadata),
       's3sync:tags': () => BbPromise.bind(this).then(this.syncBucketTags),


### PR DESCRIPTION
Apply --nos3sync flag when running `serverless remove` as well.

One use case is when I remove a stack with an S3 bucket sync-ed with serverless-s3-sync and the stack removal fails, CloudFormation leaves behind a partially-removed stack (with the S3 bucket already deleted). Trying to remove it again gives an error because serverless-s3-sync tries to clear the non-existing bucket.

In my case, I am already using serverless-s3-remover (because some buckets are sync-ed from other repositories). That plugin ignores all errors. So I want to disable bucket clearing on remove by serverless-s3-sync, since the other plugin already handles it.