### PR TITLE
Add type to CLI options

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,8 @@ class ServerlessS3Sync {
               bucket: {
                 usage: 'Specify the bucket you want to deploy (e.g. "-b myBucket1")',
                 required: true,
-                shortcut: 'b'
+                shortcut: 'b',
+                type: 'string'
               }
             },
             lifecycleEvents: [


### PR DESCRIPTION
CLI options without type definition has been deprecated.
https://www.serverless.com/framework/docs/deprecations#cli-options-extensions-type-requirement

This PR will add type definition for options.