### PR TITLE
Add autoSync property to s3Sync config

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,18 @@ custom:
 run `sls offline start --profile s3local` to sync to the local s3 bucket instead of Amazon AWS S3
 
 run `sls deploy` for normal deployment
+
+### Always disable auto sync
+
+```yaml
+custom:
+  s3Sync:
+    # Disable sync when sls deploy and sls remove
+    autoSync: false
+    buckets:
+    # A simple configuration for copying static assets
+    - bucketName: my-static-site-assets # required
+      bucketPrefix: assets/ # optional
+      localDir: dist/assets # required
+# ...
+```

--- a/index.js
+++ b/index.js
@@ -46,11 +46,13 @@ class ServerlessS3Sync {
       }
     };
 
+    const autoSync = this.getAutoSync();
+
     this.hooks = {
-      'after:deploy:deploy': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
-      'after:offline:start:init': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
-      'after:offline:start': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags),
-      'before:remove:remove': () => options.nos3sync ? undefined : BbPromise.bind(this).then(this.clear),
+      'after:deploy:deploy': () => autoSync ? BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags) : undefined,
+      'after:offline:start:init': () => autoSync ? BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags) : undefined,
+      'after:offline:start': () => autoSync ? BbPromise.bind(this).then(this.sync).then(this.syncMetadata).then(this.syncBucketTags): undefined,
+      'before:remove:remove': () => autoSync ? BbPromise.bind(this).then(this.clear) : undefined,
       's3sync:sync': () => BbPromise.bind(this).then(this.sync),
       's3sync:metadata': () => BbPromise.bind(this).then(this.syncMetadata),
       's3sync:tags': () => BbPromise.bind(this).then(this.syncBucketTags),
@@ -66,6 +68,14 @@ class ServerlessS3Sync {
 
   getEndpoint() {
       return this.serverless.service.custom.s3Sync.hasOwnProperty('endpoint') ? this.serverless.service.custom.s3Sync.endpoint : null;
+  }
+
+  getAutoSync() {
+    if (this.options.nos3sync) {
+      return false;
+    }
+    const autoSync = this.serverless.service.custom.s3Sync.hasOwnProperty('autoSync') ? this.serverless.service.custom.s3Sync.autoSync : true;
+    return String(autoSync).toUpperCase === 'TRUE';
   }
 
   client() {


### PR DESCRIPTION
Starting with v3.0.0, Serverless will report unrecognized options with a thrown error.
https://www.serverless.com/framework/docs/deprecations/#handling-of-unrecognized-cli-options

`--nos3sync` will not work in Serverless v3, so makes configurable by `autoSync` property in `s3Sync` instead.
