### PR TITLE
fix: replace duplicated file

### DIFF
--- a/index.js
+++ b/index.js
@@ -324,6 +324,7 @@ class ServerlessS3Sync {
             }
             // to avoid Unexpected Parameter error
             delete params['OnlyForEnv'];
+            filesToSync = filesToSync.filter(e => e.name !== match);
             filesToSync.push({name: match, params});
           });
         });


### PR DESCRIPTION
If there is a serverless.yml like the following, 

```
  s3Sync:
    - bucketName: example
      localDir: example
      params:
        - '**':
            CacheControl: 'public, max-age=31536000'
        - index.html:
            CacheControl: 'no-cache'
```

I expect CacheControl for index.html to be set to 'no-cache', but it may be set to 'public, max-age=31536000'.

I think the cause of this problem is that there is a duplicate in filesToSync.