### PR TITLE
fix bug where S3 client would not get instantiated with offline options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ custom:
 # ...
 ```
 
-run `sls offline start --profile s3local` to sync to the local s3 bucket instead of Amazon AWS S3
+As per [serverless-s3-local's instructions](https://github.com/ar90n/serverless-s3-local#triggering-aws-events-offline), once a local credentials profile is configured, run `sls offline start --aws-profile s3local` to sync to the local s3 bucket instead of Amazon AWS S3
+
+> `bucketNameKey` will not work in offline mode and can only be used in conjunction with valid AWS credentials, use `bucketName` instead.
 
 run `sls deploy` for normal deployment

--- a/index.js
+++ b/index.js
@@ -96,10 +96,7 @@ class ServerlessS3Sync {
     s3Options.endpoint = new provider.sdk.Endpoint(this.serverless.service.custom.s3Sync.endpoint);
     s3Options.s3ForcePathStyle = true;
   }
-    const s3Client = new provider.sdk.S3({
-      region: region,
-      credentials: awsCredentials
-    });
+    const s3Client = new provider.sdk.S3(s3Options);
     if(this.getEndpoint() && this.isOffline()) {
       //see: https://github.com/aws/aws-sdk-js/issues/1157
       s3Client.shouldDisableBodySigning = () => true


### PR DESCRIPTION
It seems as though the `s3Options` object was intended for use in instantiating `provider.sdk.S3`, but was never actually used for this...

This affected the usage of `serverless-s3-sync` in offline mode, because the endpoint would not be respected and the sync process would attempt to talk to AWS. When using credentials configured for S3RVER (serverless-s3-local), running `sls offline start` results this error:
```
InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.
```

Isolating the network results in this error:
```
UnknownEndpoint: Inaccessible host: `my-bucket-name.s3.eu-central-1.amazonaws.com' at port `undefined'. This service may not be available in the `eu-central-1' region.
```

...confirming my suspicion.

In addition, the `bucketNameKey` logic will not work correctly under these circumstances, because it attempts to do the same thing to find the `bucketName`, so I added something to the README about that; and fixed the parameter name for the AWS credentials profile.