### PR TITLE
fix: syncMetadata now takes into account that matched files can have a bucketPrefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -348,7 +348,7 @@ class ServerlessS3Sync {
                 ...file.params,
                 ...{
                   CopySource: toS3Path(file.name.replace(path.resolve(localDir) + path.sep, `${bucketName}${bucketPrefix == '' ? '' : bucketPrefix}/`)),
-                  Key: toS3Path(file.name.replace(path.resolve(localDir) + path.sep, '')),
+                  Key: toS3Path(file.name.replace(path.resolve(localDir) + path.sep, `${bucketPrefix ? bucketPrefix.replace(/^\//, '') + '/' : ''}`)),
                   Bucket: bucketName,
                   ACL: acl,
                   MetadataDirective: 'REPLACE'


### PR DESCRIPTION
## What has been implemented?

When _bucketPrefix_ is specified in options, the files are correctly copied with the prefix in the s3 bucket. If you also specify metadata in params, then _syncMetadata_ copies objects with the *REPLACE* directive with them, however, it does not take into account the _bucketPrefix_ specified.

In order to overcome that I've added the _bucketPrefix_ to the Key without a leading _/_ and with an ending _/_

Closes #86 #57

## Steps to verify

- Run _serverless deploy_ command with bucketPrefix and without params
  - It should sync the files to the s3 bucket with the prefix and without tags

- Run _serverless deploy_ command with bucketPrefix and with params
  - It should sync the files to the s3 bucket with the prefix and with tags and not duplicate on root folder. Further examples in https://github.com/k1LoW/serverless-s3-sync/issues/86 and https://github.com/k1LoW/serverless-s3-sync/issues/57
