### PR TITLE
Fix: Unify getting aws / serverless credentials

### DIFF
--- a/getAwsOptions.js
+++ b/getAwsOptions.js
@@ -1,0 +1,25 @@
+function getAwsOptions(provider) {
+  if (provider.cachedCredentials && typeof(provider.cachedCredentials.accessKeyId) != 'undefined'
+    && typeof(provider.cachedCredentials.secretAccessKey) != 'undefined'
+    && typeof(provider.cachedCredentials.sessionToken) != 'undefined') {
+
+    return {
+      // Temporarily disabled the below below because Serverless framework is not interpolating ${env:foo}
+      // in provider.credentials.region or provider.cachedCredentials.region
+      // region: provider.cachedCredentials.region,
+      region: provider.getRegion(),
+      credentials: {
+        accessKeyId: provider.cachedCredentials.accessKeyId,
+        secretAccessKey: provider.cachedCredentials.secretAccessKey,
+        sessionToken: provider.cachedCredentials.sessionToken,
+      }
+    }
+  } else {
+    return {
+      region: provider.getRegion() || provider.getCredentials().region,
+      credentials: provider.getCredentials().credentials
+    }
+  }
+}
+
+module.exports = getAwsOptions

--- a/resolveStackOutput.js
+++ b/resolveStackOutput.js
@@ -1,10 +1,9 @@
+const getAwsOptions = require('./getAwsOptions')
+
 function resolveStackOutput(plugin, outputKey) {
   const provider = plugin.serverless.getProvider('aws');
-  const awsCredentials = provider.getCredentials();
-  const cfn = new provider.sdk.CloudFormation({
-    region: provider.getRegion(),
-    credentials: awsCredentials.credentials
-  });
+  const options = getAwsOptions(provider)
+  const cfn = new provider.sdk.CloudFormation(options);
   const stackName = provider.naming.getStackName();
 
   return cfn


### PR DESCRIPTION
Hi This fixes problems when authed only using Serverless' `SERVERLESS_ACCESS_KEY` env variable, AWS credentials stored in Serverless dashboard. (not with locally stored aws credentials or aws-cli)

S3 sync was working this way only with `bucketName` and not with `bucketNameKey`, due to these differences in credentials. This MR only reuses the method originally from `client()` method again in `resolveStackOutput`. It doesn't change any logic (including the comments).

I believe this is also related/possible fix to https://github.com/k1LoW/serverless-s3-sync/issues/66