### PR TITLE
Extend deploy/remove commands with nos3sync option so that it can be used with Serverless v3

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,22 @@ class ServerlessS3Sync {
             ]
           }
         }
+      },
+      deploy: {
+        options: {
+          nos3sync: {
+            type: 'boolean',
+            usage: 'Disable sync to S3 during deploy'
+          }
+        }
+      },
+      remove: {
+        options: {
+          nos3sync: {
+            type: 'boolean',
+            usage: 'Disable sync to S3 during remove'
+          }
+        }
       }
     };
 


### PR DESCRIPTION
This is an alternative to #83 that keeps the plugin CLI option working with Serverless v3.
See discussion here: https://github.com/serverless/serverless/discussions/10618