### PR TITLE
Replace deprecated serverless.cli.log() calls with logging API and mark the plugin as requiring Serverless v3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ plugins:
   - serverless-s3-sync
 ```
 
+### Compatibility with Serverless Framework
+
+Version 2.0.0 is compatible with Serverless Framework v3, but it uses the legacy logging interface. Version 3.0.0 and later uses the [new logging interface](https://www.serverless.com/framework/docs/guides/plugins/cli-output).
+
+|serverless-s3-sync|Serverless Framework|
+|---|---|
+|v1.x|v1.x, v2.x|
+|v2.0.0|v1.x, v2.x, v3.x|
+|≥ v3.0.0|v3.x|
+
 ## Setup
 
 ```yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-sync",
-  "version": "1.12.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,14 +18,6 @@
         "pend": "~1.2.0",
         "rimraf": "~2.2.8",
         "streamsink": "~1.2.0"
-      }
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "^1.9.0"
       }
     },
     "aws-sdk": {
@@ -78,38 +70,10 @@
         "isarray": "^1.0.0"
       }
     },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "events": {
       "version": "1.1.1",
@@ -133,11 +97,6 @@
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "ieee754": {
       "version": "1.1.8",
@@ -209,14 +168,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/streamsink/-/streamsink-1.2.0.tgz",
       "integrity": "sha1-76/unx4i01ke1949yqlcP1559zw="
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "@auth0/s3": "^1.0.0",
     "bluebird": "^3.5.4",
-    "chalk": "^2.4.2",
     "mime": "^2.4.4",
     "minimatch": "^3.0.4"
+  },
+  "peerDependencies": {
+    "serverless": "^3.0.0"
   }
 }


### PR DESCRIPTION
- remove chalk from dependencies, no longer necessary
- add serverless as peerDependency

Closes: #95

NOTE: this is a breaking change (no longer works with serverless v2.x) and must be released as a new major version.
See also https://github.com/serverless/serverless/discussions/10670#discussioncomment-2141521 for why the console log has been moved to verbose and limited to minimum.