### PR TITLE
ignore `.DS_Store` files by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ class ServerlessS3Sync {
       }
       const localDir = path.join(servicePath, s.localDir);
       let filesToSync = [];
-      let ignoreFiles = [];
+      let ignoreFiles = ['.DS_Store'];
       if(Array.isArray(s.params)) {
         s.params.forEach((param) => {
           const glob = Object.keys(param)[0];


### PR DESCRIPTION
Just like the serverless framework itself, let's ignore `.DS_Store` files. I don't see a reason why they should even be synced.