### PR TITLE
support nos3sync command when using servereless-offline

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,24 @@ class ServerlessS3Sync {
             usage: 'Disable sync to S3 during remove'
           }
         }
+      },
+      offline: {
+        options: {
+          nos3sync: {
+            type: 'boolean',
+            usage: 'Disable sync to S3 for serverless offline'
+          }
+        },
+        commands: {
+          start: {
+            options: {
+              nos3sync: {
+                type: 'boolean',
+                usage: 'Disable sync to S3 for serverless offline start command'
+              }
+            }
+          }
+        }
       }
     };
 


### PR DESCRIPTION
In older versions of serverless-offline we could use the nos3sync command when starting our serverless application for local development.  

This however no longer works and we get the error "Detected unrecognized CLI options: "--nos3sync"
<img width="783" alt="Screen Shot 2023-01-04 at 4 54 12 PM" src="https://user-images.githubusercontent.com/7560722/210672001-9cabd299-916a-410a-8541-ad433ce7c545.png">


This just updates the allowed commands so that the "--nos3sync" option will work with serverless offline.
