### PR TITLE
Provide hooks configuration option to allow binding to alternative lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,18 @@ custom:
       localDir: dist/assets # required
 # ...
 ```
+
+### Sync on other hooks
+```yaml
+custom:
+  s3Sync:
+    hooks:
+      # This hook will run after the deploy:finalize hook
+      - after:deploy:finalize
+    buckets:
+    # A simple configuration for copying static assets
+    - bucketName: my-static-site-assets # required
+      bucketPrefix: assets/ # optional
+      localDir: dist/assets # required
+# ...
+```


### PR DESCRIPTION
Adds a 'hooks' option to allow providing a list of lifecycle hooks which s3 sync will be triggered on.
