### PR TITLE
Ensure that disabled rules don't execute while running a sls remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ custom:
     - bucketName: my-other-site
       localDir: path/to/other-site
       deleteRemoved: true # optional, indicates whether sync deletes files no longer present in localDir. Defaults to 'true'
-      acl: public-read # optional
+      acl: public-read # optional
       followSymlinks: true # optional
       defaultContentType: text/html # optional
       params: # optional

--- a/index.js
+++ b/index.js
@@ -272,6 +272,9 @@ class ServerlessS3Sync {
       if (s.hasOwnProperty('bucketPrefix')) {
         bucketPrefix = s.bucketPrefix;
       }
+      if (s.hasOwnProperty('enabled') && s.enabled === false) {
+        return;
+      }
       return this.getBucketName(s)
         .then(bucketName => {
           return new Promise((resolve) => {


### PR DESCRIPTION
There's a bug where if you have a disabled sync rule, like so:

```
  s3Sync:
    - bucketName: ${self:custom.hostingBucketName}
    - bucketName: ${self:custom.storybookBucketName}
      enabled: false
      localDir: storybook-static
```

And you try to run `sls remove`, if that bucket doesn't exist in the CloudFormation stack, s3-sync throws the following error:

```
Error:
NoSuchBucket: The specified bucket does not exist
    at Request.extractError ([snipped]/lib/node_modules/serverless/node_modules/aws-sdk/lib/services/s3.js:715:35)
    at Request.callListeners ([snipped]/lib/node_modules/serverless/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
```

The problem is due to the fact that in the clear command, the process doesn't exit out early if the disabled flag is set. The fix  is simply to add a guard clause in the `clear()` function, and exit if the enabled field is false. This means s3-sync won't try to retrieve the bucket, causing the above error.
